### PR TITLE
Sermons from YouTube, deduplication, and cleanup

### DIFF
--- a/.github/workflows/refresh-sermons.yml
+++ b/.github/workflows/refresh-sermons.yml
@@ -1,0 +1,30 @@
+name: Refresh sermons
+
+on:
+  schedule:
+    - cron: '0 10 * * 1'  # Every Monday at 10 AM UTC (day after Sunday service)
+  workflow_dispatch:       # Allow manual trigger from GitHub UI
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm install
+
+      - run: node scripts/fetch-sermons.mjs
+
+      - name: Commit if changed
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add src/sermons.json
+          git diff --cached --quiet && echo "No changes" || (git commit -m "Update sermons from YouTube" && git push)

--- a/build.mjs
+++ b/build.mjs
@@ -5,6 +5,9 @@ import { marked } from 'marked';
 const layout = readFileSync('src/layout.html', 'utf8');
 const DATA = JSON.parse(readFileSync('src/data.json', 'utf8'));
 
+let SERMONS = [];
+try { SERMONS = JSON.parse(readFileSync('src/sermons.json', 'utf8')); } catch { /* no file yet */ }
+
 function applyData(str) {
   let out = str;
   for (const [k, v] of Object.entries(DATA)) out = out.replaceAll(`{{${k}}}`, v);
@@ -246,10 +249,101 @@ ${imageHtml}
 }
 
 // ---------------------------------------------------------------------------
+// Sermons (from src/sermons.json, populated by scripts/fetch-sermons.mjs)
+
+function sermonVideoUrl(s) { return `https://www.youtube.com/watch?v=${esc(s.videoId)}`; }
+function sermonEmbedUrl(s) { return `https://www.youtube.com/embed/${esc(s.videoId)}`; }
+function sermonMeta(s)     { return [s.speaker, s.dateStr].filter(Boolean).join(' · '); }
+
+function buildLatestSermonHero() {
+  const s = SERMONS[0];
+  if (!s) return '';
+  return `
+<!-- Latest sermon -->
+<section class="sec-pad-s">
+  <div class="wrap">
+    <div class="label">Latest sermon</div>
+    <h2 class="display h-1" style="margin-top:8px; max-width:820px;">${esc(s.title)}</h2>
+    <div style="font-size:14px; color:var(--muted); margin-top:10px;">${esc(sermonMeta(s))}</div>
+    <div class="grid grid-bias-right" style="margin-top:36px;">
+      <div class="video-frame">
+        <iframe src="${sermonEmbedUrl(s)}" title="${esc(s.title)}" allowfullscreen loading="lazy"></iframe>
+      </div>
+      <div>
+        <div class="label">Watch</div>
+        <hr class="hr" style="margin-top:8px;">
+        <div style="margin-top:18px;">
+          <a href="${sermonVideoUrl(s)}" class="tlink">Watch on YouTube →</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>`.trimStart();
+}
+
+function buildSermonsList() {
+  const rest = SERMONS.slice(1);
+  if (!rest.length) return `    <p style="color:var(--muted); padding:24px 0;">No previous sermons available.</p>`;
+  return rest.map(s => `
+    <a class="sermon-row" href="${sermonVideoUrl(s)}">
+      <div class="date">${esc(s.dateStr)}</div>
+      <div>
+        <h3>${esc(s.title)}</h3>
+        ${s.speaker ? `<div class="who">${esc(s.speaker)}</div>` : ''}
+      </div>
+      <div class="arrow">→</div>
+    </a>`).join('\n');
+}
+
+function buildLatestSermonCard() {
+  const s = SERMONS[0];
+  if (!s) return '';
+  return `
+        <div class="label">Latest sermon</div>
+        <h3 class="display h-2" style="margin-top:6px">${esc(s.title)}</h3>
+        <div style="font-size:13px; color:var(--muted); margin-top:4px;">${esc(sermonMeta(s))}</div>
+        <div class="video-frame" style="margin-top:18px">
+          <iframe src="${sermonEmbedUrl(s)}" title="${esc(s.title)}" allowfullscreen loading="lazy"></iframe>
+        </div>
+        <div style="margin-top:14px; display:flex; gap:22px; flex-wrap:wrap;">
+          <a href="${sermonVideoUrl(s)}" class="tlink">Watch on YouTube →</a>
+          <a href="sermons.html" class="tlink">Sermon archive →</a>
+        </div>`.trimStart();
+}
+
+function buildRecentSermons() {
+  const recent = SERMONS.slice(1, 4);
+  if (!recent.length) return '';
+  const cards = recent.map(s => `
+      <div>
+        <h4 class="h-4" style="margin-top:8px">
+          <a href="${sermonVideoUrl(s)}" style="color:inherit; text-decoration:none;">${esc(s.title)}</a>
+        </h4>
+        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">${esc(sermonMeta(s))}</div>
+        <hr class="hr" style="margin-top:18px; opacity:.5">
+      </div>`).join('\n');
+  return `
+<!-- Recent messages -->
+<section style="padding-bottom: 96px;">
+  <div class="wrap">
+    <div class="label">Recent messages</div>
+    <hr class="hr" style="margin-top:8px">
+    <div class="grid grid-3" style="margin-top:24px">
+      ${cards.trimStart()}
+    </div>
+  </div>
+</section>`.trimStart();
+}
+
+// ---------------------------------------------------------------------------
 // Run
 
-const eventsListHtml = buildEventsList();
-const newsListHtml = buildNewsList();
+const eventsListHtml    = buildEventsList();
+const newsListHtml      = buildNewsList();
+const latestSermonHero  = buildLatestSermonHero();
+const sermonsList       = buildSermonsList();
+const latestSermonCard  = buildLatestSermonCard();
+const recentSermons     = buildRecentSermons();
 buildNewsArticles();
 
 const pages = readdirSync('src/pages').filter(f => f.endsWith('.html'));
@@ -273,8 +367,12 @@ for (const file of pages) {
     headerClass: meta['header-class'] || '',
     current: meta.current || '',
     body: pageBody.trimEnd()
-      .replace('{{events-list}}', eventsListHtml)
-      .replace('{{news-list}}', newsListHtml),
+      .replace('{{events-list}}',       eventsListHtml)
+      .replace('{{news-list}}',         newsListHtml)
+      .replace('{{latest-sermon-hero}}', latestSermonHero)
+      .replace('{{sermons-list}}',      sermonsList)
+      .replace('{{latest-sermon-card}}', latestSermonCard)
+      .replace('{{recent-sermons}}',    recentSermons),
   });
 
   writeFileSync(file, html);

--- a/index.html
+++ b/index.html
@@ -83,22 +83,13 @@
       </div>
       <div>
         <div class="label">Latest sermon</div>
-        <h3 class="display h-2" style="margin-top:6px">He Is Risen Indeed</h3>
-        <div style="font-size:13px; color: var(--muted); margin-top:4px;">
-          Blaine Dueck · April 19, 2026 · Easter 2026 · 38 min
-        </div>
+        <h3 class="display h-2" style="margin-top:6px">Sunday Morning Worship Service</h3>
+        <div style="font-size:13px; color:var(--muted); margin-top:4px;">Henry Redekop · Apr 19, 2026</div>
         <div class="video-frame" style="margin-top:18px">
-          <div class="placeholder">
-            <div class="circle"><div class="tri"></div></div>
-            <div class="label">YouTube · latest sermon</div>
-            <div class="t">He Is Risen Indeed — Easter 2026</div>
-          </div>
-          <!-- Replace placeholder with real embed once video ID is known:
-          <iframe src="https://www.youtube.com/embed/VIDEO_ID" title="..." allowfullscreen loading="lazy"></iframe>
-          -->
+          <iframe src="https://www.youtube.com/embed/_oogFhtNe5k" title="Sunday Morning Worship Service" allowfullscreen loading="lazy"></iframe>
         </div>
         <div style="margin-top:14px; display:flex; gap:22px; flex-wrap:wrap;">
-          <a href="https://www.youtube.com/@SpanishLookoutEMMC" class="tlink">Watch on YouTube →</a>
+          <a href="https://www.youtube.com/watch?v=_oogFhtNe5k" class="tlink">Watch on YouTube →</a>
           <a href="sermons.html" class="tlink">Sermon archive →</a>
         </div>
       </div>
@@ -106,28 +97,33 @@
   </div>
 </section>
 
-<!-- Recent messages row -->
+<!-- Recent messages -->
 <section style="padding-bottom: 96px;">
   <div class="wrap">
     <div class="label">Recent messages</div>
     <hr class="hr" style="margin-top:8px">
     <div class="grid grid-3" style="margin-top:24px">
       <div>
-        <div class="label gold">Passion Week</div>
-        <h4 class="h-4" style="margin-top:8px">The Road to the Cross</h4>
-        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">Blaine Dueck · Apr 12, 2026 · 41:02</div>
+        <h4 class="h-4" style="margin-top:8px">
+          <a href="https://www.youtube.com/watch?v=LRykrB3i-QY" style="color:inherit; text-decoration:none;">AI and the Problems Underneath</a>
+        </h4>
+        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">Blaine Dueck · Apr 12, 2026</div>
         <hr class="hr" style="margin-top:18px; opacity:.5">
       </div>
+
       <div>
-        <div class="label gold">Passion Week</div>
-        <h4 class="h-4" style="margin-top:8px">Palm Sunday · The King Arrives</h4>
-        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">Blaine Dueck · Apr 5, 2026 · 34:47</div>
+        <h4 class="h-4" style="margin-top:8px">
+          <a href="https://www.youtube.com/watch?v=mzlNni5UgCY" style="color:inherit; text-decoration:none;">Easter Sunday Sunrise Service</a>
+        </h4>
+        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">April 5, 2026</div>
         <hr class="hr" style="margin-top:18px; opacity:.5">
       </div>
+
       <div>
-        <div class="label gold">Disciples</div>
-        <h4 class="h-4" style="margin-top:8px">Living as Disciples</h4>
-        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">Guest · J. Friesen · Mar 29, 2026 · 36:20</div>
+        <h4 class="h-4" style="margin-top:8px">
+          <a href="https://www.youtube.com/watch?v=7l4tcLzCz4o" style="color:inherit; text-decoration:none;">Good Friday</a>
+        </h4>
+        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">Sherwin Thiessen · April 3, 2026</div>
         <hr class="hr" style="margin-top:18px; opacity:.5">
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "scripts": {
     "build": "node build.mjs",
+    "fetch-sermons": "node scripts/fetch-sermons.mjs",
     "dev": "node build.mjs && node --watch build.mjs & node serve.mjs"
   },
   "devDependencies": {

--- a/scripts/fetch-sermons.mjs
+++ b/scripts/fetch-sermons.mjs
@@ -1,0 +1,60 @@
+import { readFileSync, writeFileSync } from 'fs';
+
+const { channelId } = JSON.parse(readFileSync('src/data.json', 'utf8'));
+const FEED_URL = `https://www.youtube.com/feeds/videos.xml?channel_id=${channelId}`;
+
+function decode(str) {
+  return str
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+function xmlTag(block, name) {
+  const m = block.match(new RegExp(`<${name}>([\\s\\S]*?)<\\/${name}>`));
+  return m ? decode(m[1].trim()) : '';
+}
+
+function xmlAttr(block, name, attr) {
+  const m = block.match(new RegExp(`<${name}[^>]*\\s${attr}="([^"]*)"`));
+  return m ? m[1] : '';
+}
+
+function parseTitle(raw) {
+  const parts = raw.split(' - ');
+  if (parts.length < 2) return { dateStr: raw, title: '', speaker: '' };
+  const dateStr = parts[0].trim();
+  if (parts.length >= 3) {
+    return { dateStr, title: parts.slice(1, -1).join(' - ').trim(), speaker: parts[parts.length - 1].trim() };
+  }
+  return { dateStr, title: parts[1].trim(), speaker: '' };
+}
+
+let xml;
+try {
+  const res = await fetch(FEED_URL, { headers: { 'User-Agent': 'curl/8.0' } });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  xml = await res.text();
+} catch (e) {
+  console.error(`Could not fetch YouTube RSS: ${e.message}. Keeping existing src/sermons.json.`);
+  process.exit(0);
+}
+
+const sermons = [];
+const entryRe = /<entry>([\s\S]*?)<\/entry>/g;
+let m;
+while ((m = entryRe.exec(xml)) !== null) {
+  const block = m[1];
+  const videoId   = xmlTag(block, 'yt:videoId');
+  const rawTitle  = xmlTag(block, 'title');
+  const date      = xmlTag(block, 'published').slice(0, 10);
+  const thumbnail = xmlAttr(block, 'media:thumbnail', 'url');
+  const description = xmlTag(block, 'media:description');
+  const { dateStr, title, speaker } = parseTitle(rawTitle);
+  sermons.push({ videoId, title, dateStr, date, speaker, thumbnail, description });
+}
+
+writeFileSync('src/sermons.json', JSON.stringify(sermons, null, 2) + '\n');
+console.log(`Wrote ${sermons.length} sermons to src/sermons.json`);

--- a/sermons.html
+++ b/sermons.html
@@ -47,27 +47,17 @@
 <section class="sec-pad-s">
   <div class="wrap">
     <div class="label">Latest sermon</div>
-    <h2 class="display h-1" style="margin-top:8px; max-width:820px;"><em>He Is Risen</em> Indeed.</h2>
-    <div style="font-size:14px; color:var(--muted); margin-top:10px;">Blaine Dueck · Easter Sunday, April 19, 2026 · 38 min · Easter 2026</div>
-
+    <h2 class="display h-1" style="margin-top:8px; max-width:820px;">Sunday Morning Worship Service</h2>
+    <div style="font-size:14px; color:var(--muted); margin-top:10px;">Henry Redekop · Apr 19, 2026</div>
     <div class="grid grid-bias-right" style="margin-top:36px;">
       <div class="video-frame">
-        <div class="placeholder">
-          <div class="circle"><div class="tri"></div></div>
-          <div class="label">YouTube · latest sermon</div>
-          <div class="t">He Is Risen Indeed — Easter 2026</div>
-        </div>
-        <!-- <iframe src="https://www.youtube.com/embed/VIDEO_ID" title="He Is Risen Indeed" allowfullscreen loading="lazy"></iframe> -->
+        <iframe src="https://www.youtube.com/embed/_oogFhtNe5k" title="Sunday Morning Worship Service" allowfullscreen loading="lazy"></iframe>
       </div>
       <div>
-        <div class="label">Sermon notes</div>
+        <div class="label">Watch</div>
         <hr class="hr" style="margin-top:8px;">
-        <p style="margin-top:18px; font-size:15.5px; line-height:1.7; color:var(--text);">An Easter sermon on the resurrection of Jesus Christ — what it meant for the disciples, what it means for the church, and what it means for the ordinary believer this morning.</p>
-        <blockquote style="border-left: 2px solid var(--gold); padding-left:18px; margin:22px 0; font-family:var(--display); font-style:italic; font-size:20px; color:var(--ink); line-height:1.4;">
-          "He is not here; he has risen, just as he said." <br><span style="font-family:var(--body); font-style:normal; font-size:12px; letter-spacing:0.18em; text-transform:uppercase; color:var(--gold);">Matthew 28:6</span>
-        </blockquote>
         <div style="margin-top:18px;">
-          <a href="https://www.youtube.com/@SpanishLookoutEMMC" class="tlink">Watch on YouTube →</a>
+          <a href="https://www.youtube.com/watch?v=_oogFhtNe5k" class="tlink">Watch on YouTube →</a>
         </div>
       </div>
     </div>
@@ -86,58 +76,130 @@
     </div>
     <hr class="hr">
 
-    <a class="sermon-row" href="https://www.youtube.com/@SpanishLookoutEMMC">
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=LRykrB3i-QY">
       <div class="date">Apr 12, 2026</div>
       <div>
-        <h3>The Road to the Cross</h3>
-        <div class="who">Blaine Dueck · Passion Week</div>
+        <h3>AI and the Problems Underneath</h3>
+        <div class="who">Blaine Dueck</div>
       </div>
-      <div class="dur">41:02</div>
       <div class="arrow">→</div>
     </a>
-    <a class="sermon-row" href="https://www.youtube.com/@SpanishLookoutEMMC">
-      <div class="date">Apr 5, 2026</div>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=mzlNni5UgCY">
+      <div class="date">April 5, 2026</div>
       <div>
-        <h3>Palm Sunday · The King Arrives</h3>
-        <div class="who">Blaine Dueck · Passion Week</div>
+        <h3>Easter Sunday Sunrise Service</h3>
+        
       </div>
-      <div class="dur">34:47</div>
       <div class="arrow">→</div>
     </a>
-    <a class="sermon-row" href="https://www.youtube.com/@SpanishLookoutEMMC">
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=7l4tcLzCz4o">
+      <div class="date">April 3, 2026</div>
+      <div>
+        <h3>Good Friday</h3>
+        <div class="who">Sherwin Thiessen</div>
+      </div>
+      <div class="arrow">→</div>
+    </a>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=2MVmGqqo0eM">
       <div class="date">Mar 29, 2026</div>
       <div>
-        <h3>Living as Disciples</h3>
-        <div class="who">Guest · J. Friesen · Disciples</div>
+        <h3>Jericho Falls</h3>
+        <div class="who">Blaine Dueck</div>
       </div>
-      <div class="dur">36:20</div>
       <div class="arrow">→</div>
     </a>
-    <a class="sermon-row" href="https://www.youtube.com/@SpanishLookoutEMMC">
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=6AYnLJvV5iw">
       <div class="date">Mar 22, 2026</div>
       <div>
-        <h3>The Cost and Joy of Following</h3>
-        <div class="who">Blaine Dueck · Disciples</div>
+        <h3>Life Crossings</h3>
+        <div class="who">Blaine Dueck</div>
       </div>
-      <div class="dur">39:14</div>
       <div class="arrow">→</div>
     </a>
-    <a class="sermon-row" href="https://www.youtube.com/@SpanishLookoutEMMC">
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=UIxuq8ykQG8">
       <div class="date">Mar 15, 2026</div>
       <div>
-        <h3>Prayer, Honestly</h3>
-        <div class="who">Blaine Dueck · Disciples</div>
+        <h3>Believe In Them Halfway House</h3>
+        
       </div>
-      <div class="dur">32:48</div>
       <div class="arrow">→</div>
     </a>
-    <a class="sermon-row" href="https://www.youtube.com/@SpanishLookoutEMMC">
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=ZJnXxVVWCdg">
       <div class="date">Mar 8, 2026</div>
       <div>
-        <h3>The Yoke That Is Easy</h3>
-        <div class="who">Blaine Dueck · Disciples</div>
+        <h3>Sunday Morning Worship Service</h3>
+        
       </div>
-      <div class="dur">35:09</div>
+      <div class="arrow">→</div>
+    </a>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=_NdiERhPjv0">
+      <div class="date">Mar 1, 2026</div>
+      <div>
+        <h3>Melting Hearts</h3>
+        <div class="who">Blaine Dueck</div>
+      </div>
+      <div class="arrow">→</div>
+    </a>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=wSdIOqMPmac">
+      <div class="date">Feb 22, 2026</div>
+      <div>
+        <h3>Strength &amp; Courage</h3>
+        <div class="who">Blaine Dueck</div>
+      </div>
+      <div class="arrow">→</div>
+    </a>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=AltfFwAp8a8">
+      <div class="date">Feb 15, 2026</div>
+      <div>
+        <h3>Joshua Introduction</h3>
+        <div class="who">Blaine Dueck</div>
+      </div>
+      <div class="arrow">→</div>
+    </a>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=1cpNEFJ-03Q">
+      <div class="date">Feb 8, 2026</div>
+      <div>
+        <h3>Sunday Morning Worship Service</h3>
+        
+      </div>
+      <div class="arrow">→</div>
+    </a>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=H0UR1FZ8xEw">
+      <div class="date">Feb 1, 2026</div>
+      <div>
+        <h3>Sunday Morning Worship Service</h3>
+        <div class="who">Stephen Hochstetler</div>
+      </div>
+      <div class="arrow">→</div>
+    </a>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=-bn4EsAWPn4">
+      <div class="date">Jan 25, 2026</div>
+      <div>
+        <h3>Spiritual Leadership</h3>
+        <div class="who">Blaine Dueck</div>
+      </div>
+      <div class="arrow">→</div>
+    </a>
+
+    <a class="sermon-row" href="https://www.youtube.com/watch?v=WnRFd0MGaZU">
+      <div class="date">Jan 18, 2026</div>
+      <div>
+        <h3>What's New Part 2</h3>
+        <div class="who">Blaine Dueck</div>
+      </div>
       <div class="arrow">→</div>
     </a>
 

--- a/src/data.json
+++ b/src/data.json
@@ -1,6 +1,7 @@
 {
   "gmaps": "https://www.google.com/maps/place/EMMC/@17.2649496,-89.0383405,16.29z/data=!4m6!3m5!1s0x8f5e61eadaa1883b:0x9c3ebc322b9a607!8m2!3d17.2650988!4d-89.035188!16s%2Fg%2F1tfyfmtx?entry=ttu&g_ep=EgoyMDI2MDQyMS4wIKXMDSoASAFQAw%3D%3D",
   "youtube": "https://www.youtube.com/@SpanishLookoutEMMC",
+  "channelId": "UCONLtV1DtSa5f7kT_rbHxcA",
   "email": "splemmchurch@gmail.com",
   "phone": "615-2728",
   "phoneE164": "+5016152728",

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -51,57 +51,13 @@ header-class: over-hero
         </div>
       </div>
       <div>
-        <div class="label">Latest sermon</div>
-        <h3 class="display h-2" style="margin-top:6px">He Is Risen Indeed</h3>
-        <div style="font-size:13px; color: var(--muted); margin-top:4px;">
-          Blaine Dueck · April 19, 2026 · Easter 2026 · 38 min
-        </div>
-        <div class="video-frame" style="margin-top:18px">
-          <div class="placeholder">
-            <div class="circle"><div class="tri"></div></div>
-            <div class="label">YouTube · latest sermon</div>
-            <div class="t">He Is Risen Indeed — Easter 2026</div>
-          </div>
-          <!-- Replace placeholder with real embed once video ID is known:
-          <iframe src="https://www.youtube.com/embed/VIDEO_ID" title="..." allowfullscreen loading="lazy"></iframe>
-          -->
-        </div>
-        <div style="margin-top:14px; display:flex; gap:22px; flex-wrap:wrap;">
-          <a href="{{youtube}}" class="tlink">Watch on YouTube →</a>
-          <a href="sermons.html" class="tlink">Sermon archive →</a>
-        </div>
+        {{latest-sermon-card}}
       </div>
     </div>
   </div>
 </section>
 
-<!-- Recent messages row -->
-<section style="padding-bottom: 96px;">
-  <div class="wrap">
-    <div class="label">Recent messages</div>
-    <hr class="hr" style="margin-top:8px">
-    <div class="grid grid-3" style="margin-top:24px">
-      <div>
-        <div class="label gold">Passion Week</div>
-        <h4 class="h-4" style="margin-top:8px">The Road to the Cross</h4>
-        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">Blaine Dueck · Apr 12, 2026 · 41:02</div>
-        <hr class="hr" style="margin-top:18px; opacity:.5">
-      </div>
-      <div>
-        <div class="label gold">Passion Week</div>
-        <h4 class="h-4" style="margin-top:8px">Palm Sunday · The King Arrives</h4>
-        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">Blaine Dueck · Apr 5, 2026 · 34:47</div>
-        <hr class="hr" style="margin-top:18px; opacity:.5">
-      </div>
-      <div>
-        <div class="label gold">Disciples</div>
-        <h4 class="h-4" style="margin-top:8px">Living as Disciples</h4>
-        <div style="font-size:12.5px; color:var(--muted); margin-top:6px;">Guest · J. Friesen · Mar 29, 2026 · 36:20</div>
-        <hr class="hr" style="margin-top:18px; opacity:.5">
-      </div>
-    </div>
-  </div>
-</section>
+{{recent-sermons}}
 
 <!-- Photo quilt -->
 <section style="padding-bottom: 96px;">

--- a/src/pages/sermons.html
+++ b/src/pages/sermons.html
@@ -11,36 +11,7 @@ current: sermons
   </div>
 </section>
 
-<!-- Latest sermon -->
-<section class="sec-pad-s">
-  <div class="wrap">
-    <div class="label">Latest sermon</div>
-    <h2 class="display h-1" style="margin-top:8px; max-width:820px;"><em>He Is Risen</em> Indeed.</h2>
-    <div style="font-size:14px; color:var(--muted); margin-top:10px;">Blaine Dueck · Easter Sunday, April 19, 2026 · 38 min · Easter 2026</div>
-
-    <div class="grid grid-bias-right" style="margin-top:36px;">
-      <div class="video-frame">
-        <div class="placeholder">
-          <div class="circle"><div class="tri"></div></div>
-          <div class="label">YouTube · latest sermon</div>
-          <div class="t">He Is Risen Indeed — Easter 2026</div>
-        </div>
-        <!-- <iframe src="https://www.youtube.com/embed/VIDEO_ID" title="He Is Risen Indeed" allowfullscreen loading="lazy"></iframe> -->
-      </div>
-      <div>
-        <div class="label">Sermon notes</div>
-        <hr class="hr" style="margin-top:8px;">
-        <p style="margin-top:18px; font-size:15.5px; line-height:1.7; color:var(--text);">An Easter sermon on the resurrection of Jesus Christ — what it meant for the disciples, what it means for the church, and what it means for the ordinary believer this morning.</p>
-        <blockquote style="border-left: 2px solid var(--gold); padding-left:18px; margin:22px 0; font-family:var(--display); font-style:italic; font-size:20px; color:var(--ink); line-height:1.4;">
-          "He is not here; he has risen, just as he said." <br><span style="font-family:var(--body); font-style:normal; font-size:12px; letter-spacing:0.18em; text-transform:uppercase; color:var(--gold);">Matthew 28:6</span>
-        </blockquote>
-        <div style="margin-top:18px;">
-          <a href="{{youtube}}" class="tlink">Watch on YouTube →</a>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+{{latest-sermon-hero}}
 
 <!-- Archive -->
 <section class="sec-pad">
@@ -54,60 +25,7 @@ current: sermons
     </div>
     <hr class="hr">
 
-    <a class="sermon-row" href="{{youtube}}">
-      <div class="date">Apr 12, 2026</div>
-      <div>
-        <h3>The Road to the Cross</h3>
-        <div class="who">Blaine Dueck · Passion Week</div>
-      </div>
-      <div class="dur">41:02</div>
-      <div class="arrow">→</div>
-    </a>
-    <a class="sermon-row" href="{{youtube}}">
-      <div class="date">Apr 5, 2026</div>
-      <div>
-        <h3>Palm Sunday · The King Arrives</h3>
-        <div class="who">Blaine Dueck · Passion Week</div>
-      </div>
-      <div class="dur">34:47</div>
-      <div class="arrow">→</div>
-    </a>
-    <a class="sermon-row" href="{{youtube}}">
-      <div class="date">Mar 29, 2026</div>
-      <div>
-        <h3>Living as Disciples</h3>
-        <div class="who">Guest · J. Friesen · Disciples</div>
-      </div>
-      <div class="dur">36:20</div>
-      <div class="arrow">→</div>
-    </a>
-    <a class="sermon-row" href="{{youtube}}">
-      <div class="date">Mar 22, 2026</div>
-      <div>
-        <h3>The Cost and Joy of Following</h3>
-        <div class="who">Blaine Dueck · Disciples</div>
-      </div>
-      <div class="dur">39:14</div>
-      <div class="arrow">→</div>
-    </a>
-    <a class="sermon-row" href="{{youtube}}">
-      <div class="date">Mar 15, 2026</div>
-      <div>
-        <h3>Prayer, Honestly</h3>
-        <div class="who">Blaine Dueck · Disciples</div>
-      </div>
-      <div class="dur">32:48</div>
-      <div class="arrow">→</div>
-    </a>
-    <a class="sermon-row" href="{{youtube}}">
-      <div class="date">Mar 8, 2026</div>
-      <div>
-        <h3>The Yoke That Is Easy</h3>
-        <div class="who">Blaine Dueck · Disciples</div>
-      </div>
-      <div class="dur">35:09</div>
-      <div class="arrow">→</div>
-    </a>
+{{sermons-list}}
 
     <div style="margin-top:36px;">
       <a href="{{youtube}}" class="btn">Watch on YouTube →</a>

--- a/src/sermons.json
+++ b/src/sermons.json
@@ -1,0 +1,137 @@
+[
+  {
+    "videoId": "_oogFhtNe5k",
+    "title": "Sunday Morning Worship Service",
+    "dateStr": "Apr 19, 2026",
+    "date": "2026-04-20",
+    "speaker": "Henry Redekop",
+    "thumbnail": "https://i4.ytimg.com/vi/_oogFhtNe5k/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "LRykrB3i-QY",
+    "title": "AI and the Problems Underneath",
+    "dateStr": "Apr 12, 2026",
+    "date": "2026-04-13",
+    "speaker": "Blaine Dueck",
+    "thumbnail": "https://i1.ytimg.com/vi/LRykrB3i-QY/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "mzlNni5UgCY",
+    "title": "Easter Sunday Sunrise Service",
+    "dateStr": "April 5, 2026",
+    "date": "2026-04-05",
+    "speaker": "",
+    "thumbnail": "https://i.ytimg.com/vi/mzlNni5UgCY/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "7l4tcLzCz4o",
+    "title": "Good Friday",
+    "dateStr": "April 3, 2026",
+    "date": "2026-04-04",
+    "speaker": "Sherwin Thiessen",
+    "thumbnail": "https://i.ytimg.com/vi/7l4tcLzCz4o/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "2MVmGqqo0eM",
+    "title": "Jericho Falls",
+    "dateStr": "Mar 29, 2026",
+    "date": "2026-03-30",
+    "speaker": "Blaine Dueck",
+    "thumbnail": "https://i.ytimg.com/vi/2MVmGqqo0eM/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "6AYnLJvV5iw",
+    "title": "Life Crossings",
+    "dateStr": "Mar 22, 2026",
+    "date": "2026-03-23",
+    "speaker": "Blaine Dueck",
+    "thumbnail": "https://i.ytimg.com/vi/6AYnLJvV5iw/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "UIxuq8ykQG8",
+    "title": "Believe In Them Halfway House",
+    "dateStr": "Mar 15, 2026",
+    "date": "2026-03-16",
+    "speaker": "",
+    "thumbnail": "https://i.ytimg.com/vi/UIxuq8ykQG8/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "ZJnXxVVWCdg",
+    "title": "Sunday Morning Worship Service",
+    "dateStr": "Mar 8, 2026",
+    "date": "2026-03-09",
+    "speaker": "",
+    "thumbnail": "https://i.ytimg.com/vi/ZJnXxVVWCdg/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "_NdiERhPjv0",
+    "title": "Melting Hearts",
+    "dateStr": "Mar 1, 2026",
+    "date": "2026-03-02",
+    "speaker": "Blaine Dueck",
+    "thumbnail": "https://i.ytimg.com/vi/_NdiERhPjv0/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "wSdIOqMPmac",
+    "title": "Strength & Courage",
+    "dateStr": "Feb 22, 2026",
+    "date": "2026-02-23",
+    "speaker": "Blaine Dueck",
+    "thumbnail": "https://i.ytimg.com/vi/wSdIOqMPmac/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "AltfFwAp8a8",
+    "title": "Joshua Introduction",
+    "dateStr": "Feb 15, 2026",
+    "date": "2026-02-16",
+    "speaker": "Blaine Dueck",
+    "thumbnail": "https://i.ytimg.com/vi/AltfFwAp8a8/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "1cpNEFJ-03Q",
+    "title": "Sunday Morning Worship Service",
+    "dateStr": "Feb 8, 2026",
+    "date": "2026-02-09",
+    "speaker": "",
+    "thumbnail": "https://i.ytimg.com/vi/1cpNEFJ-03Q/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "H0UR1FZ8xEw",
+    "title": "Sunday Morning Worship Service",
+    "dateStr": "Feb 1, 2026",
+    "date": "2026-02-02",
+    "speaker": "Stephen Hochstetler",
+    "thumbnail": "https://i.ytimg.com/vi/H0UR1FZ8xEw/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "-bn4EsAWPn4",
+    "title": "Spiritual Leadership",
+    "dateStr": "Jan 25, 2026",
+    "date": "2026-01-26",
+    "speaker": "Blaine Dueck",
+    "thumbnail": "https://i.ytimg.com/vi/-bn4EsAWPn4/hqdefault.jpg",
+    "description": ""
+  },
+  {
+    "videoId": "WnRFd0MGaZU",
+    "title": "What's New Part 2",
+    "dateStr": "Jan 18, 2026",
+    "date": "2026-01-19",
+    "speaker": "Blaine Dueck",
+    "thumbnail": "https://i.ytimg.com/vi/WnRFd0MGaZU/hqdefault.jpg",
+    "description": ""
+  }
+]


### PR DESCRIPTION
## Summary

- **Pastor email** updated to `splemmchurch@gmail.com` everywhere
- **Google Maps link** updated to the exact EMMC location pin; now defined once in `src/data.json` and injected at build time via `{{gmaps}}` token — same for YouTube URL, email, phone, and WhatsApp
- **Design variant system removed** — deleted `explorations.html`, `design-canvas.jsx`, `tweaks-panel.jsx`, `src/shared.jsx`, `src/app.jsx`, and `src/variant-{a,b,c}.jsx` (~2,000 lines gone)
- **Sermons auto-populated from YouTube** — `src/sermons.json` is fetched from the channel RSS feed; `build.mjs` generates the latest sermon embed and archive list from it; `scripts/fetch-sermons.mjs` refreshes the data; a GitHub Actions workflow runs every Monday to pull new sermons and commit the update automatically

## Test plan

- [ ] Verify `splemmchurch@gmail.com` appears on contact and team pages
- [ ] Verify all Google Maps links open the correct EMMC pin
- [ ] Open `sermons.html` — latest sermon should show a real YouTube embed, archive should list real videos linking to individual watch URLs
- [ ] Open `index.html` — latest sermon card and recent messages grid should show real data
- [ ] Trigger the GitHub Actions workflow manually (`workflow_dispatch`) to confirm `src/sermons.json` updates correctly

https://claude.ai/code/session_018CeEKZ2aUtAb4QLMss9h6u

---
_Generated by [Claude Code](https://claude.ai/code/session_018CeEKZ2aUtAb4QLMss9h6u)_