### PR TITLE
Replace Recent Messages with Upcoming Events on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ In `src/pages/*.html`, you can use these placeholders:
 | `{{latest-sermon-hero}}` | Latest sermon with embedded video |
 | `{{latest-sermon-card}}` | Compact latest sermon card |
 | `{{sermons-list}}` | Previous sermons archive list |
+| `{{upcoming-events}}` | Next 3 upcoming events with link to all events |
 | `{{recent-sermons}}` | Three most recent sermons grid |
 
 Keys from `src/data.json` are also replaced everywhere (e.g. `{{email}}`, `{{phone}}`, `{{youtube}}`).

--- a/build.mjs
+++ b/build.mjs
@@ -336,6 +336,83 @@ function buildLatestSermonCard() {
         </div>`.trimStart();
 }
 
+function buildUpcomingEventsSection() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const files = readdirSync('src/events').filter(f => f.endsWith('.md'));
+  const events = files.map(f => {
+    const { meta } = parseFrontmatter(readFileSync(join('src/events', f), 'utf8'));
+    return meta;
+  });
+
+  events.sort((a, b) => a.date.localeCompare(b.date));
+  const upcoming = events.filter(e => parseDate(e.endDate || e.date) >= today).slice(0, 3);
+
+  function renderEventCard(e) {
+    const start = parseDate(e.date);
+    const mon = start.toLocaleDateString('en-US', { month: 'short' });
+    const day = start.getDate();
+    const dow = start.toLocaleDateString('en-US', { weekday: 'short' });
+
+    let dayHtml, dowText;
+    if (e.endDate) {
+      const endD = parseDate(e.endDate);
+      dayHtml = `${day}<span style="font-size:22px; color:var(--muted);">–${endD.getDate()}</span>`;
+      dowText = `${dow}–${endD.toLocaleDateString('en-US', { weekday: 'short' })}`;
+    } else {
+      dayHtml = `${day}`;
+      dowText = dow;
+    }
+
+    let timeText;
+    if (e.time) {
+      const dayName = start.toLocaleDateString('en-US', { weekday: 'long' });
+      timeText = `${dayName} <span class="dot">·</span> ${formatTime(e.time)}`;
+    } else if (e.endDate) {
+      const endD = parseDate(e.endDate);
+      const startName = start.toLocaleDateString('en-US', { weekday: 'long' });
+      const endName = endD.toLocaleDateString('en-US', { weekday: 'long' });
+      timeText = `${startName} through ${endName} <span class="dot">·</span> multi-day`;
+    } else {
+      timeText = start.toLocaleDateString('en-US', { weekday: 'long' });
+    }
+
+    return `
+    <a class="event-row" href="events.html">
+      <div class="event-date">
+        <div class="mon">${esc(mon)}</div>
+        <div class="day">${dayHtml}</div>
+        <div class="dow">${esc(dowText)}</div>
+      </div>
+      <div>
+        <h3>${esc(e.title)}</h3>
+        <div class="time">${timeText}</div>
+      </div>
+      <div class="arrow">→</div>
+    </a>`;
+  }
+
+  const rows = upcoming.length
+    ? upcoming.map(renderEventCard).join('\n')
+    : `    <p style="color:var(--muted); padding: 32px 0;">No upcoming events at this time.</p>`;
+
+  return `
+<!-- Upcoming events -->
+<section style="padding-bottom: 96px;">
+  <div class="wrap">
+    <div class="label">Upcoming events</div>
+    <hr class="hr" style="margin-top:8px">
+    <div style="margin-top:24px;">
+      ${rows.trimStart()}
+    </div>
+    <div style="margin-top:24px;">
+      <a href="events.html" class="tlink">All events →</a>
+    </div>
+  </div>
+</section>`.trimStart();
+}
+
 function buildRecentSermons() {
   const recent = SERMONS.slice(1, 4);
   if (!recent.length) return '';
@@ -367,13 +444,14 @@ mkdirSync('dist/news', { recursive: true });
 cpSync('src/assets', 'dist/assets', { recursive: true });
 cpSync('src/images', 'dist/images', { recursive: true });
 
-const eventsListHtml    = buildEventsList();
-const newsListHtml      = buildNewsList();
-const newsStripHtml     = buildNewsStrip();
-const latestSermonHero  = buildLatestSermonHero();
-const sermonsList       = buildSermonsList();
-const latestSermonCard  = buildLatestSermonCard();
-const recentSermons     = buildRecentSermons();
+const eventsListHtml       = buildEventsList();
+const upcomingEventsSection = buildUpcomingEventsSection();
+const newsListHtml         = buildNewsList();
+const newsStripHtml        = buildNewsStrip();
+const latestSermonHero     = buildLatestSermonHero();
+const sermonsList          = buildSermonsList();
+const latestSermonCard     = buildLatestSermonCard();
+const recentSermons        = buildRecentSermons();
 buildNewsArticles();
 
 const pages = readdirSync('src/pages').filter(f => f.endsWith('.html'));
@@ -397,13 +475,14 @@ for (const file of pages) {
     headerClass: meta['header-class'] || '',
     current: meta.current || '',
     body: pageBody.trimEnd()
-      .replace('{{events-list}}',       eventsListHtml)
-      .replace('{{news-list}}',         newsListHtml)
-      .replace('{{news-strip}}',        newsStripHtml)
-      .replace('{{latest-sermon-hero}}', latestSermonHero)
-      .replace('{{sermons-list}}',      sermonsList)
-      .replace('{{latest-sermon-card}}', latestSermonCard)
-      .replace('{{recent-sermons}}',    recentSermons),
+      .replace('{{events-list}}',          eventsListHtml)
+      .replace('{{upcoming-events}}',     upcomingEventsSection)
+      .replace('{{news-list}}',           newsListHtml)
+      .replace('{{news-strip}}',          newsStripHtml)
+      .replace('{{latest-sermon-hero}}',  latestSermonHero)
+      .replace('{{sermons-list}}',        sermonsList)
+      .replace('{{latest-sermon-card}}',  latestSermonCard)
+      .replace('{{recent-sermons}}',      recentSermons),
   });
 
   writeFileSync(join('dist', file), html);

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -57,7 +57,7 @@ header-class: over-hero
   </div>
 </section>
 
-{{recent-sermons}}
+{{upcoming-events}}
 
 <!-- Photo quilt -->
 <section style="padding-bottom: 96px;">


### PR DESCRIPTION
## Summary

- Adds `buildUpcomingEventsSection()` in `build.mjs` that reads `src/events/`, filters for future events, and renders the next 3 as clickable `event-row` links pointing to `events.html`
- Replaces the `{{recent-sermons}}` placeholder on the home page (`src/pages/index.html`) with the new `{{upcoming-events}}` placeholder
- Includes an "All events →" link below the event cards
- Documents the new `{{upcoming-events}}` placeholder in `README.md`

## Test plan

- [ ] Run `npm run build` and confirm it succeeds
- [ ] Open `dist/index.html` in a browser and verify the "Upcoming events" section appears where "Recent messages" used to be
- [ ] Confirm the next 3 upcoming events are shown (or fewer if less than 3 exist)
- [ ] Confirm clicking an event card navigates to `events.html`
- [ ] Confirm "All events →" link navigates to `events.html`
- [ ] Verify the events page (`dist/events.html`) is unaffected

Closes #6

https://claude.ai/code/session_01CRdXoeXkta5bYDmHkpg9DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRdXoeXkta5bYDmHkpg9DG)_