### PR TITLE
Remove News section from nav and home page (#19)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -20,7 +20,6 @@ const NAV = [
   { key: 'sermons', href: 'sermons.html', label: 'Sermons'    },
   { key: 'faith',   href: 'faith.html',   label: 'Our Faith'  },
   { key: 'events',  href: 'events.html',  label: 'Events'     },
-  { key: 'news',    href: 'news.html',    label: 'News'       },
   { key: 'contact', href: 'contact.html', label: 'Contact'    },
 ];
 

--- a/src/layout.html
+++ b/src/layout.html
@@ -57,7 +57,6 @@
           <li><a href="{{base}}faith.html">Our Faith</a></li>
           <li><a href="{{base}}events.html">Events</a></li>
           <li><a href="{{base}}membership.html">Membership</a></li>
-          <li><a href="{{base}}news.html">News</a></li>
         </ul>
       </div>
       <div>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -110,5 +110,3 @@ header-class: over-hero
     </div>
   </div>
 </section>
-
-{{news-strip}}


### PR DESCRIPTION
Closes #19

## What changed

- Removed the **News** item from the site navigation (`build.mjs`)
- Removed the **news-strip** banner (latest-news heading + article link) from the home page (`src/pages/index.html`)
- Removed the **News** link from the footer (`src/layout.html`)

The underlying news source files (`src/news/*.md`) and the build logic that generates individual article pages are left intact, so the content can be restored or repurposed later without losing any data.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnnRsZeUL5n9RRun9YtPMU)_