### PR TITLE
Fix: Remove all phone numbers from website pages (#23)

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -3,7 +3,5 @@
   "youtube": "https://www.youtube.com/@SpanishLookoutEMMC",
   "channelId": "UCONLtV1DtSa5f7kT_rbHxcA",
   "email": "splemmchurch@gmail.com",
-  "phone": "615-2728",
-  "phoneE164": "+5016152728",
   "whatsapp": "https://wa.me/5016152728"
 }

--- a/src/layout.html
+++ b/src/layout.html
@@ -64,7 +64,6 @@
         <h4>Contact</h4>
         <ul>
           <li>Blaine Dueck · Pastor</li>
-          <li>{{phone}}</li>
           <li><a href="{{base}}contact.html">All contacts →</a></li>
           <li><a href="{{youtube}}">YouTube</a></li>
         </ul>

--- a/src/pages/contact.html
+++ b/src/pages/contact.html
@@ -7,7 +7,7 @@ current: contact
   <div class="wrap">
     <div class="trail">Home · Contact</div>
     <h1><em>We'd love</em><br>to hear from you.</h1>
-    <p class="sub">A phone call, a message, or a Sunday-morning visit — whichever is easiest.</p>
+    <p class="sub">A message or a Sunday-morning visit — whichever is easiest.</p>
   </div>
 </section>
 
@@ -20,9 +20,6 @@ current: contact
         <div class="rule-with-label single" style="margin-top:14px;"><span class="label gold">Pastor · Spanish Lookout EMMC</span></div>
 
         <div style="margin-top: 32px; display: grid; grid-template-columns: auto 1fr; gap: 18px 28px; font-size: 16px;">
-          <div class="label" style="padding-top:4px;">Phone</div>
-          <div><a href="tel:{{phoneE164}}" style="color:var(--ink); font-family:var(--display); font-size:26px; text-decoration:none;">{{phone}}</a></div>
-
           <div class="label" style="padding-top:4px;">WhatsApp</div>
           <div><a href="{{whatsapp}}" style="color:var(--ink); font-family:var(--display); font-size:26px; text-decoration:none;">Message on WhatsApp →</a></div>
 
@@ -37,17 +34,14 @@ current: contact
           <div>
             <div class="label gold">Elder</div>
             <div style="font-family:var(--display); font-size:20px; color:var(--ink); margin-top:4px;">Albert &amp; Eileen Reimer</div>
-            <div style="color:var(--muted);">674-9000</div>
           </div>
           <div>
             <div class="label gold">Layminister</div>
             <div style="font-family:var(--display); font-size:20px; color:var(--ink); margin-top:4px;">Norman &amp; Elsie Dueck</div>
-            <div style="color:var(--muted);">610-2238</div>
           </div>
           <div>
             <div class="label gold">Deacon</div>
             <div style="font-family:var(--display); font-size:20px; color:var(--ink); margin-top:4px;">Henry &amp; Susan Wiebe</div>
-            <div style="color:var(--muted);">615-3747</div>
           </div>
         </div>
       </div>

--- a/src/pages/membership.html
+++ b/src/pages/membership.html
@@ -63,22 +63,18 @@ current: (none)
       <div class="card-outline" style="padding:28px;">
         <div class="label gold">Pastor</div>
         <div class="display h-3" style="margin-top:6px; color:var(--ink);">Blaine &amp; Melissa Dueck</div>
-        <div style="font-size:14.5px; color:var(--text); margin-top:6px;">{{phone}}</div>
       </div>
       <div class="card-outline" style="padding:28px;">
         <div class="label gold">Elder</div>
         <div class="display h-3" style="margin-top:6px; color:var(--ink);">Albert &amp; Eileen Reimer</div>
-        <div style="font-size:14.5px; color:var(--text); margin-top:6px;">674-9000</div>
       </div>
       <div class="card-outline" style="padding:28px;">
         <div class="label gold">Layminister</div>
         <div class="display h-3" style="margin-top:6px; color:var(--ink);">Norman &amp; Elsie Dueck</div>
-        <div style="font-size:14.5px; color:var(--text); margin-top:6px;">610-2238</div>
       </div>
       <div class="card-outline" style="padding:28px;">
         <div class="label gold">Deacon</div>
         <div class="display h-3" style="margin-top:6px; color:var(--ink);">Henry &amp; Susan Wiebe</div>
-        <div style="font-size:14.5px; color:var(--text); margin-top:6px;">615-3747</div>
       </div>
     </div>
   </div>

--- a/src/pages/team.html
+++ b/src/pages/team.html
@@ -25,7 +25,6 @@ current: team
         <p class="lead" style="margin-top:24px;">Blaine serves as pastor of Spanish Lookout EMMC. Each Sunday he opens the scriptures for the congregation and spends the week walking alongside people in teaching, prayer, and the ordinary shepherding of a small church.</p>
         <p class="lead">He and his wife Melissa are part of the everyday life of the community. If you are visiting, new to the faith, or simply have questions, he would be glad to talk.</p>
         <div style="display:grid; grid-template-columns: auto 1fr; gap:14px 20px; margin-top:26px; font-size:14.5px;">
-          <div class="label">Phone</div><div>{{phone}}</div>
           <div class="label">Email</div><div><a href="mailto:{{email}}" style="color:var(--ink);">{{email}}</a></div>
           <div class="label">Serves</div><div>Teaching · Preaching · Shepherding</div>
         </div>
@@ -45,7 +44,6 @@ current: team
         <div class="portrait placeholder"><div class="initials">AR</div></div>
         <div class="role">Elder</div>
         <h3 class="name">Albert &amp; Eileen Reimer</h3>
-        <div class="contact">674-9000</div>
         <p class="bio">Albert serves as an elder of the congregation — supporting the pastor, helping discern direction, and caring for the life and witness of the church.</p>
       </div>
 
@@ -53,7 +51,6 @@ current: team
         <div class="portrait placeholder"><div class="initials">ND</div></div>
         <div class="role">Layminister</div>
         <h3 class="name">Norman &amp; Elsie Dueck</h3>
-        <div class="contact">610-2238</div>
         <p class="bio">Norman serves as a layminister — sharing in preaching and teaching as the Spirit gives, and walking alongside the congregation in everyday life.</p>
       </div>
 
@@ -61,7 +58,6 @@ current: team
         <div class="portrait placeholder"><div class="initials">HW</div></div>
         <div class="role">Deacon</div>
         <h3 class="name">Henry &amp; Susan Wiebe</h3>
-        <div class="contact">615-3747</div>
         <p class="bio">Henry serves as a deacon — attending to practical service, care, and the needs of those inside and outside the congregation.</p>
       </div>
 


### PR DESCRIPTION
Closes #23

## Summary

- Removed `phone` and `phoneE164` keys from `src/data.json`
- Removed the `{{phone}}` entry from the footer in `src/layout.html`
- Removed the Phone row and `tel:` link from the contact page, and removed hard-coded phone numbers for elders/layminister/deacon
- Removed the Phone row from the team page (pastor card), and removed hard-coded phone numbers from the other team cards
- Removed phone number display from the membership page for all leader cards
- Updated the contact page sub-heading to remove the "phone call" reference
- WhatsApp contact link is retained as a messaging/social channel

Build verified clean with `npm run build`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ukmy3VxhW2e9pYe8sEvx5N)_