### PR TITLE
Remove Events from nav, homepage, and footer (#27)

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -20,7 +20,6 @@ const NAV = [
   { key: 'sermons', href: 'sermons.html', label: 'Sermons'    },
   { key: 'faith',       href: 'faith.html',       label: 'Our Mission'       },
   { key: 'confession',  href: 'confession.html',  label: 'Confession of Faith' },
-  { key: 'events',  href: 'events.html',  label: 'Events'     },
   { key: 'contact', href: 'contact.html', label: 'Contact'    },
 ];
 

--- a/src/layout.html
+++ b/src/layout.html
@@ -56,7 +56,6 @@
           <li><a href="{{base}}sermons.html">Sermons</a></li>
           <li><a href="{{base}}faith.html">Our Mission</a></li>
           <li><a href="{{base}}confession.html">Confession of Faith</a></li>
-          <li><a href="{{base}}events.html">Events</a></li>
           <li><a href="{{base}}membership.html">Membership</a></li>
         </ul>
       </div>

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -57,8 +57,6 @@ header-class: over-hero
   </div>
 </section>
 
-{{upcoming-events}}
-
 <!-- Photo quilt -->
 <section style="padding-bottom: 96px;">
   <div class="wrap">


### PR DESCRIPTION
Closes #27

## What changed

- Removed `Events` entry from the `NAV` array in `build.mjs` (nav menu)
- Removed `{{upcoming-events}}` placeholder from `src/pages/index.html` (homepage section)
- Removed the Events link from the footer "Explore" list in `src/layout.html`

The events page (`events.html`) and individual event detail pages are still built; they're just no longer linked from the main navigation, homepage, or footer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyvtRdQR4YA9JM3Ztv1K8z)_