### PR TITLE
Add Sunday Morning schedule to home page (#29)

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -57,6 +57,31 @@ header-class: over-hero
   </div>
 </section>
 
+<!-- Sunday Morning Schedule -->
+<section class="sec-pad-s" style="background:var(--cream-2); padding-top:64px; padding-bottom:64px;">
+  <div class="wrap" style="text-align:center">
+    <div class="label">Sunday Morning</div>
+    <h2 class="display h-1" style="margin-top:14px">Our Sunday Schedule</h2>
+    <div class="rule-with-label" style="margin-top:22px">
+      <span class="label gold">Every Sunday · Spanish Lookout</span>
+    </div>
+    <div style="margin-top:48px; display:grid; grid-template-columns:repeat(3,1fr); gap:32px; max-width:700px; margin-left:auto; margin-right:auto;">
+      <div>
+        <div class="label gold">9:00 am</div>
+        <div class="h-4 display" style="margin-top:10px;">Prayer</div>
+      </div>
+      <div>
+        <div class="label gold">9:15 am</div>
+        <div class="h-4 display" style="margin-top:10px;">Coffee &amp; Fellowship</div>
+      </div>
+      <div>
+        <div class="label gold">10:00 am</div>
+        <div class="h-4 display" style="margin-top:10px;">Worship Service</div>
+      </div>
+    </div>
+  </div>
+</section>
+
 {{upcoming-events}}
 
 <!-- Photo quilt -->


### PR DESCRIPTION
## Summary

Adds a Sunday Morning schedule section to the home page displaying the three-part morning programme:

- **9:00 am** — Prayer
- **9:15 am** — Coffee & Fellowship
- **10:00 am** — Worship Service

The section is placed between the welcome/sermon section and the upcoming events list, using the site's existing design language (gold labels, Display/Garamond headings, cream-2 background).

## What changed

- `src/pages/index.html` — new `<!-- Sunday Morning Schedule -->` section added before the `{{upcoming-events}}` placeholder.

Closes #29

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtQH3yzmvULNmVfcAmRPeE)_