### PR TITLE
Remove pastor name and heading from home page (#30)

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -22,8 +22,7 @@ header-class: over-hero
       <div class="cols">
         <div><div class="label gold">Service</div><div class="v">Sundays · 10 AM</div></div>
         <div><div class="label gold">Location</div><div class="v">Spanish Lookout, Belize</div></div>
-        <div><div class="label gold">Pastor</div><div class="v">Blaine Dueck</div></div>
-        <div><div class="label gold">Welcome</div><div class="v">Come as you are</div></div>
+<div><div class="label gold">Welcome</div><div class="v">Come as you are</div></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #30

Removed the "Pastor / Blaine Dueck" entry from the service strip on the home page (`src/pages/index.html`). The strip previously showed four columns (Service, Location, Pastor, Welcome) — the Pastor column has been removed, leaving the other three intact.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVve7doJ6yVQarf5pV2EWG)_