### PR TITLE
Fix: Update home page service schedule (#33)

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -20,9 +20,10 @@ header-class: over-hero
     </div>
     <div class="service-strip">
       <div class="cols">
-        <div><div class="label gold">Service</div><div class="v">Sundays · 10 AM</div></div>
-        <div><div class="label gold">Location</div><div class="v">Spanish Lookout, Belize</div></div>
-<div><div class="label gold">Welcome</div><div class="v">Come as you are</div></div>
+        <div><div class="label gold">Sunday</div><div class="v">Prayer — 9:00 am</div></div>
+        <div><div class="label gold">Sunday</div><div class="v">Coffee &amp; Fellowship — 9:15 am</div></div>
+        <div><div class="label gold">Sunday</div><div class="v">Worship Service — 10:00 am</div></div>
+        <div><div class="label gold">Prepare to visit</div><div class="v">Come as you are</div></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #33

## Summary

- Replaced the single "Service: Sundays · 10 AM" strip entry with the full Sunday morning schedule:
  - Sunday — Prayer 9:00 am
  - Sunday — Coffee & Fellowship 9:15 am
  - Sunday — Worship Service 10:00 am
  - Prepare to visit — Come as you are
- Removed the old "Location" column from the service strip (as requested by the new layout)
- Build passes successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRrvSBeFfEQ1Pi4ChMpLJh)_