### PR TITLE
Fix: Schedule strip time formatting (#35)

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -20,9 +20,9 @@ header-class: over-hero
     </div>
     <div class="service-strip">
       <div class="cols">
-        <div><div class="label gold">Sunday</div><div class="v">Prayer — 9:00 am</div></div>
-        <div><div class="label gold">Sunday</div><div class="v">Coffee &amp; Fellowship — 9:15 am</div></div>
-        <div><div class="label gold">Sunday</div><div class="v">Worship Service — 10:00 am</div></div>
+        <div><div class="label gold">Sunday</div><div class="v">Prayer<br>9:00 am</div></div>
+        <div><div class="label gold">Sunday</div><div class="v">Coffee &amp; Fellowship<br>9:15 am</div></div>
+        <div><div class="label gold">Sunday</div><div class="v">Worship Service<br>10:00 am</div></div>
         <div><div class="label gold">Prepare to visit</div><div class="v">Come as you are</div></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Closes #35

- Moved the time to a new line for each Sunday schedule item in the service strip (Prayer, Coffee & Fellowship, Worship Service)
- Removed the `—` (em dash) separator between the event name and time

**Before:** `Prayer — 9:00 am` (all on one line)  
**After:** `Prayer` on first line, `9:00 am` on second line, no dash

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Service strip on homepage shows each item with the time on its own line
- [ ] No dash/em dash visible between event name and time

---
_Generated by [Claude Code](https://claude.ai/code/session_01J1J9etZVA2nZntPiiuR6dq)_