### PR TITLE
Fix: Update "A word from the church" heading text (#40)

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -35,7 +35,7 @@ header-class: over-hero
     <div class="grid grid-bias-right">
       <div>
         <div class="label">A word from the church</div>
-        <h2 class="display h-1" style="margin-top:18px">A small fellowship, gathered around&nbsp;a great Savior.</h2>
+        <h2 class="display h-1" style="margin-top:18px">We welcome you to worship with us.</h2>
         <div class="rule-with-label single" style="margin-top:24px">
           <span class="label gold">Spanish Lookout · Cayo · Belize</span>
         </div>


### PR DESCRIPTION
Closes #40

## What changed

Updated the h2 heading under the "A word from the church" section on the home page (`src/pages/index.html`) from:

> "A small fellowship, gathered around a great Savior."

to:

> "We welcome you to worship with us."

Build passes with `npm run build`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X3Bpvhd3pEoewispZUt7S1)_