### PR TITLE
Add rotating scripture to homepage hero (#49)

### DIFF
--- a/src/assets/site.js
+++ b/src/assets/site.js
@@ -12,4 +12,25 @@
       nav.classList.toggle('open');
     });
   }
+
+  // Rotating homepage scripture — pick a random verse on each visit
+  var scriptureEl = document.getElementById('hero-scripture');
+  var referenceEl = document.getElementById('hero-reference');
+  if (scriptureEl && referenceEl) {
+    var verses = [
+      { text: '“Enter his gates with thanksgiving, and his courts with praise.”', ref: 'Psalm 100:4' },
+      { text: '“For God so loved the world that he gave his one and only Son, that whoever believes in him shall not perish but have eternal life.”', ref: 'John 3:16' },
+      { text: '“Come to me, all you who are weary and burdened, and I will give you rest.”', ref: 'Matthew 11:28' },
+      { text: '“Trust in the Lord with all your heart and lean not on your own understanding; in all your ways submit to him, and he will make your paths straight.”', ref: 'Proverbs 3:5–6' },
+      { text: '“But those who hope in the Lord will renew their strength. They will soar on wings like eagles; they will run and not grow weary, they will walk and not be faint.”', ref: 'Isaiah 40:31' },
+      { text: '“And we know that in all things God works for the good of those who love him, who have been called according to his purpose.”', ref: 'Romans 8:28' },
+      { text: '“God is our refuge and strength, an ever-present help in trouble.”', ref: 'Psalm 46:1' },
+      { text: '“Be strong and courageous. Do not be afraid; do not be discouraged, for the Lord your God will be with you wherever you go.”', ref: 'Joshua 1:9' },
+      { text: '“He has shown you, O mortal, what is good. And what does the Lord require of you? To act justly and to love mercy and to walk humbly with your God.”', ref: 'Micah 6:8' },
+      { text: '“Do not be anxious about anything, but in every situation, by prayer and petition, with thanksgiving, present your requests to God.”', ref: 'Philippians 4:6' }
+    ];
+    var verse = verses[Math.floor(Math.random() * verses.length)];
+    scriptureEl.textContent = verse.text;
+    referenceEl.textContent = verse.ref;
+  }
 })();

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -11,11 +11,11 @@ header-class: over-hero
   <div class="content">
     <div class="center">
       <div class="hero-eyebrow" style="margin-top: 22px;">Welcome to Spanish Lookout EMMC</div>
-      <div class="display h-hero scripture">
+      <div class="display h-hero scripture" id="hero-scripture">
         <em>"Enter his gates</em> with thanksgiving, and his courts with praise."
       </div>
       <div class="rule-with-label" style="margin-top:28px; opacity:0.95">
-        <span class="label cream">Psalm 100:4</span>
+        <span class="label cream" id="hero-reference">Psalm 100:4</span>
       </div>
     </div>
     <div class="service-strip">


### PR DESCRIPTION
## Summary

- Adds a pool of 10 Bible verses to the homepage hero section
- On each page visit, client-side JavaScript picks one at random and updates the scripture text and reference label
- The existing Psalm 100:4 is included in the rotation; the static markup remains the fallback for no-JS environments

## What changed

- `src/pages/index.html` — added `id="hero-scripture"` and `id="hero-reference"` to the two hero elements
- `src/assets/site.js` — added a `verses` array with 10 verses and randomization logic that runs on page load

## Test plan

- [ ] Load the homepage several times and confirm different verses appear
- [ ] Verify the reference label updates alongside the text
- [ ] Confirm no JS errors in the browser console
- [ ] Run `npm run build` and confirm it succeeds

Closes #49

https://claude.ai/code/session_0191PqFxKhWFvgwy9j9183z3

---
_Generated by [Claude Code](https://claude.ai/code/session_0191PqFxKhWFvgwy9j9183z3)_