### PR TITLE
Fix: Add "Everyone welcome" above "Come as you are" on home page (#53)

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -23,7 +23,7 @@ header-class: over-hero
         <div><div class="label gold">Sunday</div><div class="v">Prayer<br>9:00 am</div></div>
         <div><div class="label gold">Sunday</div><div class="v">Coffee &amp; Fellowship<br>9:30 am</div></div>
         <div><div class="label gold">Sunday</div><div class="v">Worship Service<br>10:00 am</div></div>
-        <div><div class="label gold">Prepare to visit</div><div class="v">Come as you are</div></div>
+        <div><div class="label gold">Prepare to visit</div><div class="v">Everyone welcome<br>Come as you are</div></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Closes #53

## What changed

In the service strip on the home page, added "Everyone welcome" as the first line above "Come as you are" in the "Prepare to visit" column. The text now reads:

> **Everyone welcome**
> Come as you are

This matches the structure of other service-strip entries that show two lines of text (e.g. "Prayer / 9:00 am").

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUQAV3p4ezHMRPnEVGtZT7)_