### PR TITLE
vrt-update: amend baseline commit instead of stacking new ones

### DIFF
--- a/.github/workflows/vrt-update.yml
+++ b/.github/workflows/vrt-update.yml
@@ -48,6 +48,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add backstop_data/bitmaps_reference/
-          git diff --staged --quiet && echo "No reference changes to commit." || \
+          if git diff --staged --quiet; then
+            echo "No reference changes to commit."
+          elif git log -1 --pretty=%s | grep -qF "Update VRT reference screenshots"; then
+            # The previous commit was also a baseline update — amend it so that
+            # consecutive VRT approvals don't pile up as separate commits on main.
+            git commit --amend --no-edit
+            git push --force-with-lease
+          else
             git commit -m "Update VRT reference screenshots"
-          git push
+            git push
+          fi


### PR DESCRIPTION
## What

When `vrt-update` runs on `main`, check whether the current HEAD commit is already a baseline update. If so, amend it instead of creating a new commit.

## Why

Every VRT approval was adding a permanent ~10 MB commit to `main`'s history. Over time this accumulates. With this change, consecutive baseline updates collapse into one commit — so `main` never has more than a single "Update VRT reference screenshots" commit in its recent history, no matter how many VRT approvals happen.

## How the check works

```bash
git log -1 --pretty=%s | grep -qF "Update VRT reference screenshots"
```

If the last commit has that exact message → amend + force-with-lease push.  
Otherwise → normal commit + push.

## Edge cases

- **First VRT update after a code merge:** last commit is the merge commit → normal new commit. ✓  
- **Second VRT update (e.g. two PRs merge in quick succession):** last commit is the previous baseline update → amend. ✓  
- **Manual dispatch on a feature branch:** last commit is unlikely to match → normal commit. ✓  
- **`--force-with-lease`** ensures the amend won't clobber a concurrent push that arrived since the checkout.

https://claude.ai/code/session_01HUgfkZ7AauSu9BtnZeeCeZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUgfkZ7AauSu9BtnZeeCeZ)_